### PR TITLE
mark package as architecture_independent

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <test_depend>python3-pytest</test_depend>
 
   <export>
+    <architecture_independent />
     <build_type>ament_python</build_type>
   </export>
 </package>


### PR DESCRIPTION
The package is pure Python + config file, it can safely be marked architecture independent, thus making it available on eg ARM64 without additional requirements. https://www.ros.org/reps/rep-0149.html#architecture-independent